### PR TITLE
[BACKPORT] Validate Ingress before adding it to the cache: Avoid duplicated domains

### DIFF
--- a/pkg/generator/caches_test.go
+++ b/pkg/generator/caches_test.go
@@ -170,8 +170,8 @@ func createTestDataForIngress(caches *Caches,
 		ingressNamespace:     ingressNamespace,
 		routes:               []*route.Route{{Name: routeName}},
 		clusters:             []*v2.Cluster{{Name: clusterName}},
-		externalVirtualHosts: []*route.VirtualHost{{Name: externalVHostName}},
-		internalVirtualHosts: []*route.VirtualHost{{Name: internalVHostName}},
+		externalVirtualHosts: []*route.VirtualHost{{Name: externalVHostName, Domains: []string{externalVHostName}}},
+		internalVirtualHosts: []*route.VirtualHost{{Name: internalVHostName, Domains: []string{internalVHostName}}},
 	}
 
 	caches.AddTranslatedIngress(&v1alpha1.Ingress{
@@ -183,6 +183,37 @@ func createTestDataForIngress(caches *Caches,
 
 	caches.AddStatusVirtualHost()
 	_ = caches.SetListeners(kubeClient)
+}
+
+func TestValidateIngress(t *testing.T) {
+	logger := zap.S()
+
+	caches := NewCaches(logger)
+	kubeClient := fake.Clientset{}
+
+	createTestDataForIngress(
+		caches,
+		"ingress_1",
+		"ingress_1_namespace",
+		"cluster_for_ingress_1",
+		"route_for_ingress_1",
+		"internal_host_for_ingress_1",
+		"external_host_for_ingress_1",
+		&kubeClient,
+	)
+
+	translatedIngress := translatedIngress{
+		ingressName:          "ingress_2",
+		ingressNamespace:     "ingress_2_namespace",
+		routes:               []*route.Route{{Name: "route_for_ingress_2"}},
+		clusters:             []*v2.Cluster{{Name: "cluster_for_ingress_2"}},
+		externalVirtualHosts: []*route.VirtualHost{{Name: "external_host_for_ingress_2", Domains: []string{"external_host_for_ingress_2"}}},
+		//This domain should clash with the cached ingress.
+		internalVirtualHosts: []*route.VirtualHost{{Name: "internal_host_for_ingress_2", Domains: []string{"internal_host_for_ingress_1"}}},
+	}
+
+	err := caches.validateIngress(&translatedIngress)
+	assert.Error(t, err, ErrDomainConflict.Error())
 }
 
 func getVHostsNames(routeConfigs []v2.RouteConfiguration) ([]string, error) {

--- a/pkg/generator/generator.go
+++ b/pkg/generator/generator.go
@@ -82,11 +82,12 @@ func addIngressToCaches(caches *Caches,
 	if err != nil {
 		return err
 	}
-	if ingressTranslation != nil {
-		caches.AddTranslatedIngress(ingress, ingressTranslation)
+
+	if ingressTranslation == nil {
+		return nil
 	}
 
-	return nil
+	return caches.AddTranslatedIngress(ingress, ingressTranslation)
 }
 
 func listenersFromVirtualHosts(externalVirtualHosts []*route.VirtualHost,

--- a/pkg/knative/ingress.go
+++ b/pkg/knative/ingress.go
@@ -25,11 +25,9 @@ import (
 )
 
 func MarkIngressReady(ingress *networkingv1alpha1.Ingress) {
-	status := ingress.Status
 	internalDomain := domainForServiceName(config.InternalServiceName)
 	externalDomain := domainForServiceName(config.ExternalServiceName)
 
-	status.InitializeConditions()
 	var domain string
 
 	if ingress.Spec.Visibility == networkingv1alpha1.IngressVisibilityClusterLocal {
@@ -38,7 +36,7 @@ func MarkIngressReady(ingress *networkingv1alpha1.Ingress) {
 		domain = externalDomain
 	}
 
-	status.MarkLoadBalancerReady(
+	ingress.Status.MarkLoadBalancerReady(
 		[]networkingv1alpha1.LoadBalancerIngressStatus{{
 			DomainInternal: domain,
 		}},
@@ -49,9 +47,7 @@ func MarkIngressReady(ingress *networkingv1alpha1.Ingress) {
 			DomainInternal: internalDomain,
 		}},
 	)
-	status.MarkNetworkConfigured()
-	status.ObservedGeneration = ingress.GetGeneration()
-	ingress.Status = status
+	ingress.Status.MarkNetworkConfigured()
 }
 
 func domainForServiceName(serviceName string) string {

--- a/pkg/reconciler/ingress/ingress.go
+++ b/pkg/reconciler/ingress/ingress.go
@@ -67,8 +67,16 @@ func (reconciler *Reconciler) Reconcile(ctx context.Context, key string) error {
 	ingress := original.DeepCopy()
 	ingress.SetDefaults(ctx)
 	ingress.Status.InitializeConditions()
+	// This is the generation we are going to handle during this reconciliation loop.
+	ingress.Status.ObservedGeneration = ingress.GetGeneration()
 
-	if err := reconciler.updateIngress(ingress); err != nil {
+	err = reconciler.updateIngress(ingress)
+	if err == generator.ErrDomainConflict {
+		// If we had an error due to a duplicated domain, we must mark the ingress as failed with a
+		// custom status. We don't want to return an error in this case as we want to update its status.
+		reconciler.logger.Errorw(err.Error(), ingress.Name, ingress.Namespace)
+		ingress.Status.MarkLoadBalancerFailed("DomainConflict", "Ingress rejected as its domain conflicts with another ingress")
+	} else if err != nil {
 		return fmt.Errorf("failed to update ingress: %w", err)
 	}
 


### PR DESCRIPTION
Backporting this upstream fix: https://github.com/knative/net-kourier/pull/39. A fix for SRVKS-521.