### PR TITLE
Add Dockerfile in openshift/ci-operator/kourier-images/kourier

### DIFF
--- a/openshift/ci-operator/kourier-images/kourier/Dockerfile
+++ b/openshift/ci-operator/kourier-images/kourier/Dockerfile
@@ -1,0 +1,7 @@
+FROM openshift/origin-base
+
+USER 1001
+
+ADD kourier /app/kourier
+EXPOSE 18000 19000
+ENTRYPOINT ["/app/kourier"]


### PR DESCRIPTION
Since https://github.com/knative-sandbox/net-kourier/commit/584b3e31885019cf7baf1ec4dd5ba71dc1ed3a7d,
upstream net-kourier removes Dockerfile so test fails with missing Dockerfile:

https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/openshift_release/14185/rehearse-14185-pull-ci-openshift-knative-net-kourier-release-0.19-images/1336488646630445056

This patch adds Dockerfile into openshift/ci-operator/kourier-images/kourier and configure CI to use the Dockerfile.

The Dockerfile verified that it works as https://github.com/openshift/release/pull/14185 on [release-0.19 branch](https://github.com/openshift-knative/net-kourier/commit/9fba2e052f16c9d960cc554cd451bd44a2987527).

/cc @markusthoemmes  
