### PR TITLE
Add USER stanza so image doesn't run as  root

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,5 +4,7 @@ COPY . .
 RUN go build -mod vendor -o /tmp/kourier ./cmd/kourier
 
 FROM openshift/origin-base
+USER 65532
+
 COPY --from=builder /tmp/kourier /ko-app/kourier
 ENTRYPOINT ["/ko-app/kourier"]


### PR DESCRIPTION
As per title. This fixes the respective error in OCP since the kourier deployments now define `runAsNonRoot`.