### PR TITLE
Update OWNERS

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -2,11 +2,16 @@
 
 approvers:
 - alanfx
-- bbrowning
-- jcrossley3
 - mgencur
+- mvinkler
+- nak3
+- rhuss
+- skonto
+
 reviewers:
 - alanfx
-- bbrowning
-- jcrossley3
 - mgencur
+- mvinkler
+- nak3
+- rhuss
+- skonto


### PR DESCRIPTION
This patch syncs OWNERS file with https://github.com/openshift/knative-serving/blob/main/OWNERS.

Without this, all Serving members cannot approve release repo like https://github.com/openshift/release/pull/26253.

/cc @rhuss @skonto 