### PR TITLE
[RELEASE-1.4][SRVKS-953] Add runAsNonRoot patch

### DIFF
--- a/openshift/patches/001-kourier-nonroot.patch
+++ b/openshift/patches/001-kourier-nonroot.patch
@@ -1,0 +1,13 @@
+diff --git a/openshift/release/artifacts/0-kourier.yaml b/openshift/release/artifacts/0-kourier.yaml
+index 77ca06f0..1731e709 100644
+--- a/openshift/release/artifacts/0-kourier.yaml
++++ b/openshift/release/artifacts/0-kourier.yaml
+@@ -427,7 +427,7 @@ spec:
+           securityContext:
+             allowPrivilegeEscalation: false
+             readOnlyRootFilesystem: false
+-            runAsNonRoot: false
++            runAsNonRoot: true
+             capabilities:
+               drop:
+                 - all

--- a/openshift/release/artifacts/0-kourier.yaml
+++ b/openshift/release/artifacts/0-kourier.yaml
@@ -427,7 +427,7 @@ spec:
           securityContext:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: false
-            runAsNonRoot: false
+            runAsNonRoot: true
             capabilities:
               drop:
                 - all

--- a/openshift/release/download_release_artifacts.sh
+++ b/openshift/release/download_release_artifacts.sh
@@ -36,3 +36,5 @@ sed -i -e '/labels:$/a \    networking.knative.dev\/ingress-provider: kourier' "
 # Make Kourier rollout in a more defensive way so no requests get dropped.
 # TODO: Can probably be removed in 1.21 and/or be sent upstream.
 git apply "${patches_path}/001-kourier-rollout.patch"
+git apply "${patches_path}/001-kourier-cert.patch"
+git apply "${patches_path}/001-kourier-nonroot.patch"


### PR DESCRIPTION
This patch adds runAsNonRoot patch to Kourier.

Verified by https://github.com/openshift-knative/serverless-operator/pull/1677

* context
OCP 4.12 changes the security policy and we cannot run `runAsNonRoot: false` by default. The Kourier Gateway (envoy) image has an root user and so upstream needs to use `runAsNonRoot: false` but OpenShift can run it with arbitrary users so this patch is only for Downstream.

/cc @skonto  