### PR TITLE
[RELEASE-1.8] fix go version in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.ci.openshift.org/openshift/release:golang-1.17 AS builder
+FROM registry.ci.openshift.org/openshift/release:golang-1.18 AS builder
 WORKDIR /app/
 COPY . .
 RUN go build -mod vendor -o /tmp/kourier ./cmd/kourier


### PR DESCRIPTION
- As per title, version should 1.18.