### PR TITLE
[SRVKS-946] Add keep alive patch to release artifacts

### DIFF
--- a/openshift/patches/003-keepalive.patch
+++ b/openshift/patches/003-keepalive.patch
@@ -1,0 +1,21 @@
+diff --git a/openshift/release/artifacts/0-kourier.yaml b/openshift/release/artifacts/0-kourier.yaml
+index 0d9e85e5..aa13d9bc 100644
+--- a/openshift/release/artifacts/0-kourier.yaml
++++ b/openshift/release/artifacts/0-kourier.yaml
+@@ -110,6 +110,16 @@ data:
+                     pipe:
+                       path: /tmp/envoy.admin
+         - name: xds_cluster
++          # This keepalive is recommended by envoy docs.
++          # https://www.envoyproxy.io/docs/envoy/latest/api-docs/xds_protocol
++          typed_extension_protocol_options:
++            envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
++              "@type": type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
++              explicit_http_config:
++                http2_protocol_options:
++                  connection_keepalive:
++                    interval: 30s
++                    timeout: 5s
+           connect_timeout: 1s
+           type: strict_dns
+           load_assignment:

--- a/openshift/release/artifacts/0-kourier.yaml
+++ b/openshift/release/artifacts/0-kourier.yaml
@@ -110,6 +110,16 @@ data:
                     pipe:
                       path: /tmp/envoy.admin
         - name: xds_cluster
+          # This keepalive is recommended by envoy docs.
+          # https://www.envoyproxy.io/docs/envoy/latest/api-docs/xds_protocol
+          typed_extension_protocol_options:
+            envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
+              "@type": type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
+              explicit_http_config:
+                http2_protocol_options:
+                  connection_keepalive:
+                    interval: 30s
+                    timeout: 5s
           connect_timeout: 1s
           type: strict_dns
           load_assignment:

--- a/openshift/release/download_release_artifacts.sh
+++ b/openshift/release/download_release_artifacts.sh
@@ -37,3 +37,4 @@ sed -i -e '/labels:$/a \    networking.knative.dev\/ingress-provider: kourier' "
 # TODO: Can probably be removed in 1.21 and/or be sent upstream.
 git apply "${patches_path}/001-kourier-rollout.patch"
 git apply "${patches_path}/002-backport.patch"
+git apply "${patches_path}/003-keepalive.patch"


### PR DESCRIPTION
* Both https://github.com/openshift-knative/net-kourier/commit/261c6ef88c5e769a20aaaf409f1ec73143f8ba6d
and https://github.com/openshift-knative/net-kourier/pull/33 missed the release artifacts patching and so S-O didnt fetch them before release cut. 
* Will have to unify configs in the future to avoid inconsistency
* Available already in 1.8+