### PR TITLE
Add a patch for kourier pdb minAvailable: 1

### DIFF
--- a/openshift/patches/002-pdb-minavailable.patch
+++ b/openshift/patches/002-pdb-minavailable.patch
@@ -1,0 +1,13 @@
+diff --git a/config/300-gateway.yaml b/config/300-gateway.yaml
+index 00cbc5d4..dc280b9c 100644
+--- a/config/300-gateway.yaml
++++ b/config/300-gateway.yaml
+@@ -194,7 +194,7 @@ metadata:
+     app.kubernetes.io/version: devel
+     app.kubernetes.io/name: knative-serving
+ spec:
+-  minAvailable: 80%
++  minAvailable: 1
+   selector:
+     matchLabels:
+       app: 3scale-kourier-gateway

--- a/openshift/release/download_release_artifacts.sh
+++ b/openshift/release/download_release_artifacts.sh
@@ -49,6 +49,7 @@ patches_path="${SCRIPT_DIR}/../patches"
 
 # TODO: [SRVKS-610] These values should be replaced by operator instead of sed.
 git apply "${patches_path}/001-service-location.patch"
+git apply "${patches_path}/002-pdb-minavailable.patch"
 
 # Add label to the config-network, which is deployed in knative-serving-ingress namespace.
 sed -i -e 's/app.kubernetes.io\/component: networking/app.kubernetes.io\/component: kourier\n    networking.knative.dev\/ingress-provider: kourier/' "$CONFIG_NETWORK"


### PR DESCRIPTION
Adds a patch to set pdb minAvailable to 1 (starting with 1.10 of `net-kourier`).