### PR TITLE
[RELEASE-1.8] [SRVKS-1046] Add missing probes

### DIFF
--- a/cmd/kourier/main.go
+++ b/cmd/kourier/main.go
@@ -42,5 +42,6 @@ func main() {
 	}
 
 	ctx := informerfiltering.GetContextWithFilteringLabelSelector(signals.NewContext())
+	ctx = sharedmain.WithHealthProbesDisabled(ctx)
 	sharedmain.MainWithContext(ctx, config.ControllerName, kourierIngressController.NewController)
 }

--- a/cmd/kourier/main.go
+++ b/cmd/kourier/main.go
@@ -42,6 +42,5 @@ func main() {
 	}
 
 	ctx := informerfiltering.GetContextWithFilteringLabelSelector(signals.NewContext())
-	ctx = sharedmain.WithHealthProbesDisabled(ctx)
 	sharedmain.MainWithContext(ctx, config.ControllerName, kourierIngressController.NewController)
 }

--- a/config/300-controller.yaml
+++ b/config/300-controller.yaml
@@ -62,6 +62,13 @@ spec:
           readinessProbe:
             exec:
               command: ["/ko-app/kourier", "-probe-addr=:18000"]
+            periodSeconds: 10
+            failureThreshold: 3
+          livenessProbe:
+            exec:
+              command: [ "/ko-app/kourier", "-probe-addr=:18000" ]
+            periodSeconds: 10
+            failureThreshold: 6
           securityContext:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true

--- a/config/300-gateway.yaml
+++ b/config/300-gateway.yaml
@@ -89,6 +89,18 @@ spec:
               scheme: HTTP
             initialDelaySeconds: 10
             periodSeconds: 5
+            failureThreshold: 3
+          livenessProbe:
+            httpGet:
+              httpHeaders:
+                - name: Host
+                  value: internalkourier
+              path: /ready
+              port: 8081
+              scheme: HTTP
+            initialDelaySeconds: 10
+            periodSeconds: 5
+            failureThreshold: 6
       volumes:
         - name: config-volume
           configMap:

--- a/pkg/generator/status_vhost.go
+++ b/pkg/generator/status_vhost.go
@@ -28,7 +28,7 @@ import (
 )
 
 // Generates an internal virtual host that signals that the Envoy instance has
-// been configured, this endpoint is used by the kubernetes readiness probe.
+// been configured, this endpoint is used by the kubernetes readiness, liveness probes.
 func statusVHost() *route.VirtualHost {
 	vhost := envoy.NewVirtualHost(
 		config.InternalKourierDomain,


### PR DESCRIPTION
- Backport of https://github.com/knative-sandbox/net-kourier/pull/1029, no need to disable the default probes for sharedmain as they are not available on the branch.