### PR TITLE
[release-1.8] [SRVKS-1035] Add debug log for cluster (#1016)

### DIFF
--- a/pkg/generator/ingress_translator.go
+++ b/pkg/generator/ingress_translator.go
@@ -206,6 +206,7 @@ func (translator *IngressTranslator) translateIngress(ctx context.Context, ingre
 					}
 				}
 				cluster := envoy.NewCluster(splitName, connectTimeout, publicLbEndpoints, http2, transportSocket, typ)
+				logger.Debugf("adding cluster: %v", cluster)
 				clusters = append(clusters, cluster)
 
 				weightedCluster := envoy.NewWeightedCluster(splitName, uint32(split.Percent), split.AppendHeaders)


### PR DESCRIPTION
This patch cherry-picks 708f7c8053debe1d357c26b6ccb6ede48fb3fd4a
It is very hard to debug an issue like SRVKS-1035 without this because endpoint(activator)'s IPs could be changed.

/cc @ReToCode @skonto 