### PR TITLE
Validate GH action only on PR

### DIFF
--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -2,11 +2,6 @@
 name: Validate
 
 on:
-  push:
-    branches:
-      - '**'
-    tags:
-      - 'v*.*.*'
   pull_request:
     branches:
       - '**'


### PR DESCRIPTION
It seems `{ github.base_ref }` value does not work for push event. 
It is enough to validate when PR is sent so this patch drops the push.

/cc @ReToCode @skonto 