### PR TITLE
[release-v1.9] Add `_example: ""` to extra configmap

### DIFF
--- a/openshift/release/artifacts/0-kourier.yaml
+++ b/openshift/release/artifacts/0-kourier.yaml
@@ -611,6 +611,7 @@ metadata:
     networking.knative.dev/ingress-provider: kourier
     app.kubernetes.io/version: "release-v1.9"
 data:
+  _example: ""
 ---
 # Copyright 2018 The Knative Authors
 #
@@ -637,6 +638,7 @@ metadata:
     networking.knative.dev/ingress-provider: kourier
     app.kubernetes.io/version: "release-v1.9"
 data:
+  _example: ""
 ---
 # Copyright 2018 The Knative Authors
 #
@@ -663,3 +665,4 @@ metadata:
     networking.knative.dev/ingress-provider: kourier
     app.kubernetes.io/version: "release-v1.9"
 data:
+  _example: ""

--- a/openshift/release/extra/logging.yaml
+++ b/openshift/release/extra/logging.yaml
@@ -23,3 +23,4 @@ metadata:
     networking.knative.dev/ingress-provider: kourier
     app.kubernetes.io/version: devel
 data:
+  _example: ""

--- a/openshift/release/extra/network.yaml
+++ b/openshift/release/extra/network.yaml
@@ -23,3 +23,4 @@ metadata:
     networking.knative.dev/ingress-provider: kourier
     app.kubernetes.io/version: devel
 data:
+  _example: ""

--- a/openshift/release/extra/observability.yaml
+++ b/openshift/release/extra/observability.yaml
@@ -23,3 +23,4 @@ metadata:
     networking.knative.dev/ingress-provider: kourier
     app.kubernetes.io/version: devel
 data:
+  _example: ""


### PR DESCRIPTION
This patch adds `_example: ""` to extra configmap.

Without this, operator fails to reconcile as https://github.com/openshift-knative/serverless-operator/pull/2113#issuecomment-1582472140

https://github.com/openshift-knative/serverless-operator/pull/2114 verified this fix.

/cc @ReToCode @skonto 