### PR TITLE
Modify script to name kourier artifact yaml to `net-kourier.yaml`

### DIFF
--- a/openshift/release/download_release_artifacts.sh
+++ b/openshift/release/download_release_artifacts.sh
@@ -36,7 +36,7 @@ function resolve_file() {
 }
 
 readonly YAML_OUTPUT_DIR="openshift/release/artifacts/"
-readonly KOURIER_YAML=${YAML_OUTPUT_DIR}/0-kourier.yaml
+readonly KOURIER_YAML=${YAML_OUTPUT_DIR}/net-kourier.yaml
 readonly patches_path="${SCRIPT_DIR}/../patches"
 
 # Clean up


### PR DESCRIPTION
# Context
It would be nice to change the name of the file to 0-net-kourier in the future to align it with the istio filename. Also change the policy one to 0-net-istio-policies.yaml or something similar to that, for readability reasons.
In other words have a convention using a prefix, as we have for the Serving files and do this at the midstream.

# Changes
- Renamed the release artifacts to a aligned pattern

JIRA: https://issues.redhat.com/browse/SRVKS-1038

/assign @nak3 , @skonto 