### PR TITLE
[RELEASE-1.8] [SRVKS-1078] Fix client rate by allowing to pass QPS and burst parameters.

### DIFF
--- a/cmd/kourier/main.go
+++ b/cmd/kourier/main.go
@@ -23,6 +23,7 @@ import (
 	"knative.dev/net-kourier/pkg/config"
 	"knative.dev/net-kourier/pkg/reconciler/informerfiltering"
 	kourierIngressController "knative.dev/net-kourier/pkg/reconciler/ingress"
+	"knative.dev/pkg/environment"
 	"knative.dev/pkg/signals"
 
 	// This defines the shared main for injected controllers.
@@ -30,11 +31,14 @@ import (
 )
 
 var (
-	probeAddr = flag.String("probe-addr", "", "run this binary as a health check against the given address")
+	fSet      = flag.NewFlagSet("probe", flag.ExitOnError)
+	probeAddr = fSet.String("probe-addr", "", "run this binary as a health check against the given address")
 )
 
 func main() {
-	flag.Parse()
+	env := new(environment.ClientConfig)
+	env.InitFlags(fSet)
+	_ = fSet.Parse(os.Args[1:])
 
 	// Run the binary as a health checker if the respective flag is given.
 	if *probeAddr != "" {

--- a/openshift/release/artifacts/0-kourier.yaml
+++ b/openshift/release/artifacts/0-kourier.yaml
@@ -521,6 +521,7 @@ spec:
       containers:
         - image: ko://knative.dev/net-kourier/cmd/kourier
           name: controller
+          command: ["/ko-app/kourier", "-kube-api-burst=200", "-kube-api-qps=200"]
           env:
             - name: CERTS_SECRET_NAMESPACE
               value: ""


### PR DESCRIPTION
- Allows to pass QPS and burst parameters.
-  Created over ksvcs , it comes up pretty fast, logs for [net-kourier-controller-8c9687699-7j8rk](https://gist.github.com/skonto/b8fcba3029f1319fb5968044da5e5ed1)  bellow :
```

$ oc get po -n knative-serving-ingress
NAME                                      READY   STATUS        RESTARTS   AGE
3scale-kourier-gateway-747cc8579c-2wfdq   0/1     Running       0          11s
3scale-kourier-gateway-747cc8579c-gf4z2   0/1     Running       0          11s
3scale-kourier-gateway-747cc8579c-p9b96   1/1     Terminating   0          4m15s
3scale-kourier-gateway-747cc8579c-z29z9   0/1     Terminating   0          4m16s
net-kourier-controller-8c9687699-7j8rk    1/1     Running       0          11s
net-kourier-controller-8c9687699-fqr5w    1/1     Running       0          11s

$ oc get ingresses.networking.internal.knative.dev --all-namespaces | wc -l
233

```
