### PR TITLE
[RELEASE-v1.9] Add QPS and Burst patch

### DIFF
--- a/config/300-controller.yaml
+++ b/config/300-controller.yaml
@@ -49,6 +49,10 @@ spec:
               value: ""
             - name: CERTS_SECRET_NAME
               value: ""
+            - name: KUBE_API_BURST
+              value: "200"
+            - name: KUBE_API_QPS
+              value: "200"
             - name: SYSTEM_NAMESPACE
               valueFrom:
                 fieldRef:

--- a/openshift/patches/003-pqs-burst.patch
+++ b/openshift/patches/003-pqs-burst.patch
@@ -1,0 +1,37 @@
+diff --git a/vendor/knative.dev/pkg/environment/client_config.go b/vendor/knative.dev/pkg/environment/client_config.go
+index 04d4220b..aef33927 100644
+--- a/vendor/knative.dev/pkg/environment/client_config.go
++++ b/vendor/knative.dev/pkg/environment/client_config.go
+@@ -19,8 +19,10 @@ package environment
+ import (
+ 	"flag"
+ 	"fmt"
++	"log"
+ 	"math"
+ 	"os"
++	"strconv"
+ 
+ 	"k8s.io/client-go/rest"
+ 	"k8s.io/client-go/tools/clientcmd"
+@@ -45,9 +47,19 @@ func (c *ClientConfig) InitFlags(fs *flag.FlagSet) {
+ 	fs.StringVar(&c.Kubeconfig, "kubeconfig", os.Getenv("KUBECONFIG"),
+ 		"Path to a kubeconfig. Only required if out-of-cluster.")
+ 
+-	fs.IntVar(&c.Burst, "kube-api-burst", 0, "Maximum burst for throttle.")
++	fs.IntVar(&c.Burst, "kube-api-burst", int(envVarOrDefault("KUBE_API_BURST", 0)), "Maximum burst for throttle.")
+ 
+-	fs.Float64Var(&c.QPS, "kube-api-qps", 0, "Maximum QPS to the server from the client.")
++	fs.Float64Var(&c.QPS, "kube-api-qps", envVarOrDefault("KUBE_API_QPS", 0.0), "Maximum QPS to the server from the client.")
++}
++
++func envVarOrDefault(key string, val float64) float64 {
++	var err error
++	if v := os.Getenv(key); v != "" {
++		if val, err = strconv.ParseFloat(v, 64); err != nil {
++			log.Fatal(err)
++		}
++	}
++	return val
+ }
+ 
+ func (c *ClientConfig) GetRESTConfig() (*rest.Config, error) {

--- a/openshift/patches/003-pqs-burst.patch
+++ b/openshift/patches/003-pqs-burst.patch
@@ -1,3 +1,18 @@
+diff --git a/config/300-controller.yaml b/config/300-controller.yaml
+index 9c943b36..793ced82 100644
+--- a/config/300-controller.yaml
++++ b/config/300-controller.yaml
+@@ -49,6 +49,10 @@ spec:
+               value: ""
+             - name: CERTS_SECRET_NAME
+               value: ""
++            - name: KUBE_API_BURST
++              value: "200"
++            - name: KUBE_API_QPS
++              value: "200"
+             - name: SYSTEM_NAMESPACE
+               valueFrom:
+                 fieldRef:
 diff --git a/vendor/knative.dev/pkg/environment/client_config.go b/vendor/knative.dev/pkg/environment/client_config.go
 index 04d4220b..aef33927 100644
 --- a/vendor/knative.dev/pkg/environment/client_config.go

--- a/openshift/release/artifacts/net-kourier.yaml
+++ b/openshift/release/artifacts/net-kourier.yaml
@@ -358,6 +358,10 @@ spec:
               value: ""
             - name: CERTS_SECRET_NAME
               value: ""
+            - name: KUBE_API_BURST
+              value: "200"
+            - name: KUBE_API_QPS
+              value: "200"
             - name: SYSTEM_NAMESPACE
               valueFrom:
                 fieldRef:

--- a/vendor/knative.dev/pkg/environment/client_config.go
+++ b/vendor/knative.dev/pkg/environment/client_config.go
@@ -19,8 +19,10 @@ package environment
 import (
 	"flag"
 	"fmt"
+	"log"
 	"math"
 	"os"
+	"strconv"
 
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
@@ -45,9 +47,19 @@ func (c *ClientConfig) InitFlags(fs *flag.FlagSet) {
 	fs.StringVar(&c.Kubeconfig, "kubeconfig", os.Getenv("KUBECONFIG"),
 		"Path to a kubeconfig. Only required if out-of-cluster.")
 
-	fs.IntVar(&c.Burst, "kube-api-burst", 0, "Maximum burst for throttle.")
+	fs.IntVar(&c.Burst, "kube-api-burst", int(envVarOrDefault("KUBE_API_BURST", 0)), "Maximum burst for throttle.")
 
-	fs.Float64Var(&c.QPS, "kube-api-qps", 0, "Maximum QPS to the server from the client.")
+	fs.Float64Var(&c.QPS, "kube-api-qps", envVarOrDefault("KUBE_API_QPS", 0.0), "Maximum QPS to the server from the client.")
+}
+
+func envVarOrDefault(key string, val float64) float64 {
+	var err error
+	if v := os.Getenv(key); v != "" {
+		if val, err = strconv.ParseFloat(v, 64); err != nil {
+			log.Fatal(err)
+		}
+	}
+	return val
 }
 
 func (c *ClientConfig) GetRESTConfig() (*rest.Config, error) {

--- a/vendor/knative.dev/pkg/environment/client_config.go
+++ b/vendor/knative.dev/pkg/environment/client_config.go
@@ -19,10 +19,8 @@ package environment
 import (
 	"flag"
 	"fmt"
-	"log"
 	"math"
 	"os"
-	"strconv"
 
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
@@ -47,19 +45,9 @@ func (c *ClientConfig) InitFlags(fs *flag.FlagSet) {
 	fs.StringVar(&c.Kubeconfig, "kubeconfig", os.Getenv("KUBECONFIG"),
 		"Path to a kubeconfig. Only required if out-of-cluster.")
 
-	fs.IntVar(&c.Burst, "kube-api-burst", int(envVarOrDefault("KUBE_API_BURST", 0)), "Maximum burst for throttle.")
+	fs.IntVar(&c.Burst, "kube-api-burst", 0, "Maximum burst for throttle.")
 
-	fs.Float64Var(&c.QPS, "kube-api-qps", envVarOrDefault("KUBE_API_QPS", 0.0), "Maximum QPS to the server from the client.")
-}
-
-func envVarOrDefault(key string, val float64) float64 {
-	var err error
-	if v := os.Getenv(key); v != "" {
-		if val, err = strconv.ParseFloat(v, 64); err != nil {
-			log.Fatal(err)
-		}
-	}
-	return val
+	fs.Float64Var(&c.QPS, "kube-api-qps", 0, "Maximum QPS to the server from the client.")
 }
 
 func (c *ClientConfig) GetRESTConfig() (*rest.Config, error) {


### PR DESCRIPTION
This patch adds QPS and Burst patch to modify via env value.
The default value should be defined by Serverless Operator.