### PR TITLE
[release-v1.9] Define knative-serving-ingress for Kourier Gateway xdp client

### DIFF
--- a/config/200-bootstrap.yaml
+++ b/config/200-bootstrap.yaml
@@ -103,7 +103,7 @@ data:
                 endpoint:
                   address:
                     socket_address:
-                      address: "net-kourier-controller"
+                      address: "net-kourier-controller.knative-serving-ingress"
                       port_value: 18000
           type: STRICT_DNS
     admin:

--- a/openshift/patches/001-service-location.patch
+++ b/openshift/patches/001-service-location.patch
@@ -7,7 +7,7 @@ index 890c66b1..8596712a 100644
                    address:
                      socket_address:
 -                      address: "net-kourier-controller.knative-serving"
-+                      address: "net-kourier-controller"
++                      address: "net-kourier-controller.knative-serving-ingress"
                        port_value: 18000
            type: STRICT_DNS
      admin:

--- a/openshift/release/artifacts/net-kourier.yaml
+++ b/openshift/release/artifacts/net-kourier.yaml
@@ -128,7 +128,7 @@ data:
                 endpoint:
                   address:
                     socket_address:
-                      address: "net-kourier-controller"
+                      address: "net-kourier-controller.knative-serving-ingress"
                       port_value: 18000
           type: STRICT_DNS
     admin:


### PR DESCRIPTION
This patch adds `.knative-serving-ingress` suffix for Kourier Gateway XDP client.

The gateway sends DNS query with `net-kourier-controller.` and gets NXDOMAIN error before querying `net-kourier-controller.knative-serving-ingress`. This patch can avoid the error.

Verified on https://github.com/openshift-knative/serverless-operator/pull/2153

Fix [SRVKS-1098](https://issues.redhat.com/browse/SRVKS-1098)

/cc @ReToCode @skonto 