### PR TITLE
[release-v1.10] Define knative-serving-ingress for Kourier Gateway xdp client

### DIFF
--- a/config/200-bootstrap.yaml
+++ b/config/200-bootstrap.yaml
@@ -103,7 +103,7 @@ data:
                 endpoint:
                   address:
                     socket_address:
-                      address: "net-kourier-controller"
+                      address: "net-kourier-controller.knative-serving-ingress"
                       port_value: 18000
           type: STRICT_DNS
     admin:

--- a/openshift/patches/001-service-location.patch
+++ b/openshift/patches/001-service-location.patch
@@ -7,7 +7,7 @@ index 890c66b1..8596712a 100644
                    address:
                      socket_address:
 -                      address: "net-kourier-controller.knative-serving"
-+                      address: "net-kourier-controller"
++                      address: "net-kourier-controller.knative-serving-ingress"
                        port_value: 18000
            type: STRICT_DNS
      admin:

--- a/openshift/release/artifacts/net-kourier.yaml
+++ b/openshift/release/artifacts/net-kourier.yaml
@@ -128,7 +128,7 @@ data:
                 endpoint:
                   address:
                     socket_address:
-                      address: "net-kourier-controller"
+                      address: "net-kourier-controller.knative-serving-ingress"
                       port_value: 18000
           type: STRICT_DNS
     admin:


### PR DESCRIPTION
This patch is same with https://github.com/openshift-knative/net-kourier/pull/89 but against 1.10.