### PR TITLE
Define knative-serving-ingress for Kourier Gateway xdp client

### DIFF
--- a/openshift/patches/001-service-location.patch
+++ b/openshift/patches/001-service-location.patch
@@ -7,7 +7,7 @@ index 890c66b1..8596712a 100644
                    address:
                      socket_address:
 -                      address: "net-kourier-controller.knative-serving"
-+                      address: "net-kourier-controller"
++                      address: "net-kourier-controller.knative-serving-ingress"
                        port_value: 18000
            type: STRICT_DNS
      admin:


### PR DESCRIPTION
This patch is same with https://github.com/openshift-knative/net-kourier/pull/89 but against main.

/cc @ReToCode @skonto 