### PR TITLE
Upstream `create-release-branch.sh` to use correct version

### DIFF
--- a/openshift/release/create-release-branch.sh
+++ b/openshift/release/create-release-branch.sh
@@ -15,9 +15,12 @@ set -e # Exit immediately on error.
 
 release=$1
 
+# Set upstream release without "v" prefix. e.g. release-v1.11 => release-1.11
+upstream_release=release-${release#"release-v"}
+
 # Fetch the latest upstream and checkout the new branch.
-git fetch upstream ${release}
-git checkout upstream/${release}
+git fetch upstream ${upstream_release}
+git checkout upstream/${upstream_release}
 
 # Copy the openshift extra files from the OPENSHIFT/main branch.
 git fetch openshift main
@@ -37,6 +40,7 @@ git commit -am ":fire: Generate artifacts."
 echo "
 Now ready to create a new branch. Push it by:
 
+  $ git checkout -b ${release}
   $ git push openshift ${release}
 
 "

--- a/openshift/release/create-release-branch.sh
+++ b/openshift/release/create-release-branch.sh
@@ -28,11 +28,7 @@ git checkout openshift/main -- openshift OWNERS
 git add openshift OWNERS
 git commit -m "Add openshift specific files."
 
-# Drop the release-suffix and add the micro version with '0'.
-# e.g. release-1.9 => 1.9.0
-VERSION=${release#"release-"}.0
-
-openshift/release/download_release_artifacts.sh ${VERSION}
+openshift/release/download_release_artifacts.sh ${release}
 git add .
 git commit -am ":fire: Generate artifacts."
 


### PR DESCRIPTION
There are two changes in this PR.

Recently we added `v` prefix for downstream branch but upstream does not have it.
Hence, we need the following line:

```sh
upstream_release=release-${release#"release-v"}
```

Also, the downstream's version label is equal to branch name so it should be:

```sh
openshift/release/download_release_artifacts.sh ${release}
```
