### PR TITLE
[release-v1.9][SRVKS-1093] Increase gateway's memory limit to 750m

### DIFF
--- a/config/300-gateway.yaml
+++ b/config/300-gateway.yaml
@@ -110,7 +110,7 @@ spec:
               memory: 200Mi
             limits:
               cpu: 500m
-              memory: 500Mi
+              memory: 750Mi
       volumes:
         - name: config-volume
           configMap:

--- a/openshift/patches/004-memory-limit.patch
+++ b/openshift/patches/004-memory-limit.patch
@@ -1,0 +1,13 @@
+diff --git a/config/300-gateway.yaml b/config/300-gateway.yaml
+index d689955a..e89b000f 100644
+--- a/config/300-gateway.yaml
++++ b/config/300-gateway.yaml
+@@ -114,7 +114,7 @@ spec:
+               memory: 200Mi
+             limits:
+               cpu: 500m
+-              memory: 500Mi
++              memory: 750Mi
+       volumes:
+         - name: config-volume
+           configMap:

--- a/openshift/release/artifacts/net-kourier.yaml
+++ b/openshift/release/artifacts/net-kourier.yaml
@@ -535,7 +535,7 @@ spec:
               memory: 200Mi
             limits:
               cpu: 500m
-              memory: 500Mi
+              memory: 750Mi
       volumes:
         - name: config-volume
           configMap:


### PR DESCRIPTION
As per title, this patch adds memory limit patch.

Alternatively we can increase the limit in upstream or adjust the default via operator but the proper limit should be determined later so this is done by patch.