### PR TITLE
[MAIN] Move to go 1.21

### DIFF
--- a/openshift/ci-operator/build-image/Dockerfile
+++ b/openshift/ci-operator/build-image/Dockerfile
@@ -1,3 +1,3 @@
 # Dockerfile to bootstrap build and test in openshift-ci
 
-FROM registry.ci.openshift.org/openshift/release:golang-1.19
+FROM registry.ci.openshift.org/openshift/release:golang-1.21

--- a/openshift/ci-operator/knative-images/kourier/Dockerfile
+++ b/openshift/ci-operator/knative-images/kourier/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.ci.openshift.org/openshift/release:golang-1.19 AS builder
+FROM registry.ci.openshift.org/openshift/release:golang-1.21 AS builder
 WORKDIR /app/
 COPY . .
 RUN go build -mod vendor -o /tmp/kourier ./cmd/kourier


### PR DESCRIPTION
- Similar to https://github.com/openshift-knative/net-kourier/pull/124
- See also https://github.com/openshift-knative/serverless-operator/pull/2451