### PR TITLE
Drop uid and guid in 3scale-kourier-gateway

### DIFF
--- a/config/300-gateway.yaml
+++ b/config/300-gateway.yaml
@@ -72,8 +72,6 @@ spec:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: false
             runAsNonRoot: true
-            runAsUser: 65534
-            runAsGroup: 65534
             capabilities:
               drop:
                 - ALL

--- a/openshift/patches/003-dropuid.patch
+++ b/openshift/patches/003-dropuid.patch
@@ -1,0 +1,13 @@
+diff --git a/config/300-gateway.yaml b/config/300-gateway.yaml
+index 4a71d3eb..6c9df8f9 100644
+--- a/config/300-gateway.yaml
++++ b/config/300-gateway.yaml
+@@ -72,8 +72,6 @@ spec:
+             allowPrivilegeEscalation: false
+             readOnlyRootFilesystem: false
+             runAsNonRoot: true
+-            runAsUser: 65534
+-            runAsGroup: 65534
+             capabilities:
+               drop:
+                 - ALL

--- a/openshift/release/artifacts/net-kourier.yaml
+++ b/openshift/release/artifacts/net-kourier.yaml
@@ -486,8 +486,6 @@ spec:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: false
             runAsNonRoot: true
-            runAsUser: 65534
-            runAsGroup: 65534
             capabilities:
               drop:
                 - ALL


### PR DESCRIPTION
# Changes
- Drop uid and guid in 3scale-kourier-gateway
- As per https://github.com/openshift-knative/serverless-operator/pull/2524#discussion_r1505441409

/assign @skonto 

I'll do a manual port to `main` if https://github.com/openshift-knative/serverless-operator/pull/2524 works.