### PR TITLE
Onboard net-kourier to automatic Dockerfile generation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,3 @@
+generate-release:
+	./openshift/generate.sh
+.PHONY: generate-release

--- a/openshift/ci-operator/build-image/Dockerfile
+++ b/openshift/ci-operator/build-image/Dockerfile
@@ -1,3 +1,25 @@
-# Dockerfile to bootstrap build and test in openshift-ci
+# DO NOT EDIT! Generated Dockerfile.
 
-FROM registry.ci.openshift.org/openshift/release:rhel-8-release-golang-1.22-openshift-4.17
+FROM registry.ci.openshift.org/ocp/4.17:cli-artifacts as tools
+
+# Dockerfile to bootstrap build and test in openshift-ci
+FROM registry.ci.openshift.org/openshift/release:rhel-8-release-golang-1.22-openshift-4.17 as builder
+
+ARG TARGETARCH
+
+COPY --from=tools /usr/share/openshift/linux_$TARGETARCH/oc.rhel8 /usr/bin/oc
+
+RUN ln -s /usr/bin/oc /usr/bin/kubectl
+
+RUN yum install -y httpd-tools
+
+RUN wget https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 && \
+    chmod 700 ./get-helm-3
+
+RUN ./get-helm-3 --version v3.11.3 --no-sudo && helm version
+
+RUN GOFLAGS='' go install github.com/mikefarah/yq/v3@latest
+
+# go install creates $GOPATH/.cache with root permissions, we delete it here
+# to avoid permission issues with the runtime users
+RUN rm -rf $GOPATH/.cache

--- a/openshift/ci-operator/knative-images/kourier/Dockerfile
+++ b/openshift/ci-operator/knative-images/kourier/Dockerfile
@@ -1,10 +1,31 @@
-FROM registry.ci.openshift.org/openshift/release:rhel-8-release-golang-1.22-openshift-4.17 AS builder
-WORKDIR /app/
-COPY . .
-RUN go build -mod vendor -o /tmp/kourier ./cmd/kourier
+# DO NOT EDIT! Generated Dockerfile for cmd/kourier.
+ARG GO_BUILDER=registry.ci.openshift.org/openshift/release:rhel-8-release-golang-1.22-openshift-4.17
+ARG GO_RUNTIME=registry.access.redhat.com/ubi8/ubi-minimal
 
-FROM openshift/origin-base
+FROM $GO_BUILDER as builder
+
+COPY . .
+
+ENV CGO_ENABLED=1
+ENV GOEXPERIMENT=strictfipsruntime
+
+RUN go build -tags strictfipsruntime -o /usr/bin/main ./cmd/kourier
+
+FROM $GO_RUNTIME
+
+ARG VERSION=knative-v1.15
+
+COPY --from=builder /usr/bin/main /ko-app/kourier
+
 USER 65532
 
-COPY --from=builder /tmp/kourier /ko-app/kourier
+LABEL \
+      com.redhat.component="openshift-serverless-1-net-kourier-kourier-rhel8-container" \
+      name="openshift-serverless-1/net-kourier-kourier-rhel8" \
+      version=$VERSION \
+      summary="Red Hat OpenShift Serverless 1 Net Kourier Kourier" \
+      maintainer="serverless-support@redhat.com" \
+      description="Red Hat OpenShift Serverless 1 Net Kourier Kourier" \
+      io.k8s.display-name="Red Hat OpenShift Serverless 1 Net Kourier Kourier"
+
 ENTRYPOINT ["/ko-app/kourier"]

--- a/openshift/ci-operator/source-image/Dockerfile
+++ b/openshift/ci-operator/source-image/Dockerfile
@@ -1,0 +1,7 @@
+# DO NOT EDIT! Generated Dockerfile.
+
+FROM src
+
+RUN chmod +x vendor/k8s.io/code-generator/generate-groups.sh || true
+RUN chmod +x vendor/knative.dev/pkg/hack/generate-knative.sh || true
+RUN chmod +x vendor/k8s.io/code-generator/generate-internal-groups.sh || true

--- a/openshift/generate.sh
+++ b/openshift/generate.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root_dir=$(dirname "$(realpath "${BASH_SOURCE[0]}")")/..
+
+tmp_dir=$(mktemp -d)
+git clone --branch main https://github.com/openshift-knative/hack "$tmp_dir"
+
+pushd "$tmp_dir"
+go install github.com/openshift-knative/hack/cmd/generate
+popd
+
+rm -rf "$tmp_dir"
+
+$(go env GOPATH)/bin/generate \
+  --root-dir "${repo_root_dir}" \
+  --generators dockerfile \
+  --includes cmd \
+  --app-file-fmt "/ko-app/%s" \
+  --dockerfile-image-builder-fmt "registry.ci.openshift.org/openshift/release:rhel-8-release-golang-%s-openshift-4.17"

--- a/openshift/generate.sh
+++ b/openshift/generate.sh
@@ -4,14 +4,7 @@ set -euo pipefail
 
 repo_root_dir=$(dirname "$(realpath "${BASH_SOURCE[0]}")")/..
 
-tmp_dir=$(mktemp -d)
-git clone --branch main https://github.com/openshift-knative/hack "$tmp_dir"
-
-pushd "$tmp_dir"
-go install github.com/openshift-knative/hack/cmd/generate
-popd
-
-rm -rf "$tmp_dir"
+go install github.com/openshift-knative/hack/cmd/generate@latest
 
 $(go env GOPATH)/bin/generate \
   --root-dir "${repo_root_dir}" \

--- a/openshift/images.yaml
+++ b/openshift/images.yaml
@@ -1,0 +1,1 @@
+knative.dev/net-kourier/cmd/kourier: registry.ci.openshift.org/openshift/net-kourier-kourier:knative-v1.15

--- a/openshift/project.yaml
+++ b/openshift/project.yaml
@@ -1,0 +1,3 @@
+project:
+  tag: knative-v1.15
+  imagePrefix: net-kourier

--- a/openshift/release/create-release-branch.sh
+++ b/openshift/release/create-release-branch.sh
@@ -24,8 +24,13 @@ git checkout upstream/"${upstream_release}"
 
 # Copy the openshift extra files from the OPENSHIFT/main branch.
 git fetch openshift main
-git checkout openshift/main -- openshift OWNERS
-git add openshift OWNERS
+git checkout openshift/main -- openshift OWNERS Makefile
+
+tag=${release/release-/}
+yq write --inplace openshift/project.yaml project.tag "knative-$tag"
+make generate-release
+
+git add openshift OWNERS Makefile
 git commit -m "Add openshift specific files."
 
 openshift/release/download_release_artifacts.sh "${release}"


### PR DESCRIPTION
Related to https://issues.redhat.com/browse/SRVCOM-3255 (we missed net-kourier and net-istio)

This allows running Github action https://github.com/openshift-knative/hack/actions/workflows/run-command-repository.yaml in order to generate images.

PR for main branch: https://github.com/openshift-knative/net-kourier/pull/145
