### PR TITLE
Allow to disable envoy server header injection (#1311)

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,9 +1,7 @@
+version: "2"
 run:
-  timeout: 5m
-
   build-tags:
     - e2e
-
 linters:
   enable:
     - asciicheck
@@ -11,9 +9,27 @@ linters:
     - gosec
     - prealloc
     - revive
-    - stylecheck
+    - staticcheck
     - tparallel
     - unconvert
     - unparam
   disable:
     - errcheck
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
+formatters:
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$

--- a/config/200-config.yaml
+++ b/config/200-config.yaml
@@ -80,3 +80,6 @@ data:
     # Use ',' separated values like "ECDHE-ECDSA-AES128-GCM-SHA256,ECDHE-ECDSA-CHACHA20-POLY1305"
     # The default uses the default cipher suites of the envoy version.
     cipher-suites: ""
+
+    # Disable the Envoy server header injection in the response when response has no such header.
+    disable-envoy-server-header: "false"

--- a/pkg/config/configmap.go
+++ b/pkg/config/configmap.go
@@ -52,6 +52,8 @@ const (
 
 	// TracingCollectorFullEndpoint is the config map key to configure tracing at kourier gateway level
 	TracingCollectorFullEndpoint = "tracing-collector-full-endpoint"
+
+	disableEnvoyServerHeader = "disable-envoy-server-header"
 )
 
 func DefaultConfig() *Kourier {
@@ -64,6 +66,7 @@ func DefaultConfig() *Kourier {
 		CipherSuites:               nil,
 		EnableCryptoMB:             false,
 		UseRemoteAddress:           false,
+		DisableEnvoyServerHeader:   false,
 	}
 }
 
@@ -81,6 +84,7 @@ func NewConfigFromMap(configMap map[string]string) (*Kourier, error) {
 		cm.AsStringSet(cipherSuites, &nc.CipherSuites),
 		cm.AsBool(enableCryptoMB, &nc.EnableCryptoMB),
 		asTracing(TracingCollectorFullEndpoint, &nc.Tracing),
+		cm.AsBool(disableEnvoyServerHeader, &nc.DisableEnvoyServerHeader),
 	); err != nil {
 		return nil, err
 	}
@@ -161,4 +165,6 @@ type Kourier struct {
 	CipherSuites sets.Set[string]
 	// Tracing specifies the configuration for gateway tracing
 	Tracing Tracing
+	// Disable Server Header
+	DisableEnvoyServerHeader bool
 }

--- a/pkg/envoy/api/http_connection_manager.go
+++ b/pkg/envoy/api/http_connection_manager.go
@@ -52,6 +52,7 @@ func NewHTTPConnectionManager(routeConfigName string, kourierConfig *config.Kour
 	})
 	enableAccessLog := kourierConfig.EnableServiceAccessLogging
 	enableProxyProtocol := kourierConfig.EnableProxyProtocol
+	disableEnvoyServerHeader := kourierConfig.DisableEnvoyServerHeader
 	idleTimeout := kourierConfig.IdleTimeout
 
 	mgr := &hcm.HttpConnectionManager{
@@ -78,6 +79,11 @@ func NewHTTPConnectionManager(routeConfigName string, kourierConfig *config.Kour
 	if enableProxyProtocol {
 		//Force the connection manager to use the real remote address of the client connection.
 		mgr.UseRemoteAddress = &wrapperspb.BoolValue{Value: true}
+	}
+
+	if disableEnvoyServerHeader {
+		//Force the connection manager to skip envoy's server header if none is present
+		mgr.ServerHeaderTransformation = hcm.HttpConnectionManager_PASS_THROUGH
 	}
 
 	if enableAccessLog {


### PR DESCRIPTION
* Allow to disable envoy server header injection

* style

Fixes [SRVKS-1252](https://issues.redhat.com/browse/SRVKS-1252)


If we want or need a fix earlier. It creates a config nob to disable headers injections. So it shouldn't be low risk. 🤞 
/cc @maschmid @skonto 