### PR TITLE
[release-v1.16] update rpms scan image

### DIFF
--- a/.tekton/docker-build.yaml
+++ b/.tekton/docker-build.yaml
@@ -368,7 +368,7 @@ spec:
       - name: name
         value: deprecated-image-check
       - name: bundle
-        value: quay.io/konflux-ci/tekton-catalog/task-deprecated-image-check:0.5@sha256:c49732039f105de809840be396f83ead8c46f6a6948e1335b76d37e9eb469574
+        value: quay.io/konflux-ci/tekton-catalog/task-deprecated-image-check:0.5@sha256:1f57224c21021b2d497bac73312386d7421ec949241280a20102192acf1d01d3
       - name: kind
         value: task
       resolver: bundles

--- a/.tekton/docker-build.yaml
+++ b/.tekton/docker-build.yaml
@@ -534,7 +534,7 @@ spec:
       - name: name
         value: rpms-signature-scan
       - name: bundle
-        value: quay.io/konflux-ci/konflux-vanguard/task-rpms-signature-scan:0.2@sha256:49ff6d117c3e9dc3966d1244e118e168b3501742ec14c3a4161a276ff48d04d5
+        value: quay.io/konflux-ci/konflux-vanguard/task-rpms-signature-scan:0.2@sha256:edb72ea58ea9671a5112dfddffd4940f2006783ef33a8011876116a4df2d2f58
       - name: kind
         value: task
       resolver: bundles


### PR DESCRIPTION
Fix for the error - https://github.com/openshift-knative/net-kourier/runs/49815425897 
Task Statuses:
Pipeline ocp-serverless-tenant/net-kourier-kourier-116-on-push-vj6zm can't be Run; it contains Tasks that don't exist: Couldn't retrieve Task "resolver type bundles\nname = rpms-signature-scan\n": error requesting remote resource: error getting "bundleresolver" "ocp-serverless-tenant/bundles-1982360e9a539174fe7822fce8d43d67": cannot retrieve the oci image: GET https://quay.io/v2/konflux-ci/konflux-vanguard/task-rpms-signature-scan/manifests/sha256:49ff6d117c3e9dc3966d1244e118e168b3501742ec14c3a4161a276ff48d04d5: MANIFEST_UNKNOWN: manifest unknown; map[] 
