### PR TITLE
chore(KONFLUX-6210): fix and set name and cpe label for net-kourier-kourier-115

### DIFF
--- a/openshift/ci-operator/knative-images/kourier/Dockerfile
+++ b/openshift/ci-operator/knative-images/kourier/Dockerfile
@@ -30,6 +30,7 @@ LABEL \
       description="Red Hat OpenShift Serverless 1 Net Kourier Kourier" \
       io.k8s.display-name="Red Hat OpenShift Serverless 1 Net Kourier Kourier" \
       io.k8s.description="Red Hat OpenShift Serverless Net Kourier Kourier" \
-      io.openshift.tags="kourier"
+      io.openshift.tags="kourier" \
+      cpe="cpe:/a:redhat:openshift_serverless:1.35::el8"
 
 ENTRYPOINT ["/ko-app/kourier"]


### PR DESCRIPTION
For https://issues.redhat.com/browse/KONFLUX-6210, clair needs access to a name and cpe label that it can use to look up the image in VEX statements.

See also release-engineering/rhtap-ec-policy#149

Signed-off-by: Ralph Bean <rbean@redhat.com>
Assisted-by: Gemini
